### PR TITLE
Окончательный фикс для bx_temp

### DIFF
--- a/vm_menu/ansible/playbooks/install_new_full_environment.yaml
+++ b/vm_menu/ansible/playbooks/install_new_full_environment.yaml
@@ -5,7 +5,7 @@
   become: yes
   gather_facts: no
   vars:
-    - bx_temporary_files_directory: "{{ path_sites }}/tmp/{{ domain }}/"
+    - bx_temporary_files_directory: "{{ path_sites }}/tmp/{{ db_name }}/"
   tasks:
     - include_tasks: "tasks/add_cron_agents.yaml"
       vars:

--- a/vm_menu/ansible/playbooks/roles/create_site/files/nginx_files/custom_conf.d/site_settings/default/bx_temp.conf
+++ b/vm_menu/ansible/playbooks/roles/create_site/files/nginx_files/custom_conf.d/site_settings/default/bx_temp.conf
@@ -1,10 +1,10 @@
 # Settings BX_TEMPORARY_FILES_DIRECTORY
 location ~* ^/bx_tmp_download/ {
     internal;
-    rewrite /bx_tmp_download/(.+) /tmp/default/$1 last;
+    rewrite /bx_tmp_download/(.+) /tmp/bitrix/$1 last;
 }
 
-location ~* ^/tmp/default/ {
+location ~* ^/tmp/bitrix/ {
     internal;
-    root /usr/share/nginx/html;
+    root /var/www/html;
 }

--- a/vm_menu/ansible/playbooks/roles/create_site/tasks/main.yml
+++ b/vm_menu/ansible/playbooks/roles/create_site/tasks/main.yml
@@ -39,6 +39,19 @@
         group: "{{ group_user_server_sites }}"
         mode: "{{ permissions_sites_files }}"
 
+    - name: Extract database name from .settings.php
+      ansible.builtin.shell: |
+        php -r '
+        $settings = include "{{ path_site_from_links }}/bitrix/.settings.php";
+        echo $settings["connections"]["value"]["default"]["database"];
+        '
+      register: db_name_result
+      changed_when: false
+
+    - name: Set db_name variable
+      ansible.builtin.set_fact:
+        db_name: "{{ db_name_result.stdout }}"
+
   when: mode == 'link'
 
 ############## FULL MODE ##############
@@ -126,8 +139,6 @@
         group: "{{ group_user_server_sites }}"
         mode: "{{ permissions_sites_dirs }}"
         recurse: yes
-      vars:
-        bx_temporary_files_directory: "{{ path_sites }}/tmp/{{ db_name }}/"
 
     - include_tasks: "tasks/add_cron_agents.yaml"
       vars:
@@ -198,4 +209,3 @@
   systemd:
     name: "{{ service_apache_name }}"
     state: restarted
-

--- a/vm_menu/ansible/playbooks/roles/create_site/tasks/main.yml
+++ b/vm_menu/ansible/playbooks/roles/create_site/tasks/main.yml
@@ -39,19 +39,6 @@
         group: "{{ group_user_server_sites }}"
         mode: "{{ permissions_sites_files }}"
 
-    - name: Extract database name from .settings.php
-      ansible.builtin.shell: |
-        php -r '
-        $settings = include "{{ path_site_from_links }}/bitrix/.settings.php";
-        echo $settings["connections"]["value"]["default"]["database"];
-        '
-      register: db_name_result
-      changed_when: false
-
-    - name: Set db_name variable
-      ansible.builtin.set_fact:
-        db_name: "{{ db_name_result.stdout }}"
-
   when: mode == 'link'
 
 ############## FULL MODE ##############

--- a/vm_menu/ansible/playbooks/roles/create_site/tasks/main.yml
+++ b/vm_menu/ansible/playbooks/roles/create_site/tasks/main.yml
@@ -126,6 +126,8 @@
         group: "{{ group_user_server_sites }}"
         mode: "{{ permissions_sites_dirs }}"
         recurse: yes
+      vars:
+        bx_temporary_files_directory: "{{ path_sites }}/tmp/{{ db_name }}/"
 
     - include_tasks: "tasks/add_cron_agents.yaml"
       vars:

--- a/vm_menu/ansible/playbooks/roles/create_site/templates/nginx_conf/bx_temp.j2
+++ b/vm_menu/ansible/playbooks/roles/create_site/templates/nginx_conf/bx_temp.j2
@@ -1,10 +1,10 @@
 # Settings BX_TEMPORARY_FILES_DIRECTORY
 location ~* ^/bx_tmp_download/ {
     internal;
-    rewrite /bx_tmp_download/(.+) /tmp/{{ domain }}/$1 last;
+    rewrite /bx_tmp_download/(.+) /tmp/{{ db_name }}/$1 last;
 }
 
-location ~* ^/tmp/{{ domain }}/ {
+location ~* ^/tmp/{{ db_name }}/ {
     internal;
-    root /usr/share/nginx/html;
+    root {{ path_sites }};
 }

--- a/vm_menu/ansible/playbooks/roles/create_site/vars/main.yml
+++ b/vm_menu/ansible/playbooks/roles/create_site/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 # vars file for create_site
-bx_temporary_files_directory: "{{ path_sites }}/tmp/{{ domain }}/"
+bx_temporary_files_directory: "{{ path_sites }}/tmp/{{ db_name }}/"

--- a/vm_menu/bash_scripts/functions.sh
+++ b/vm_menu/bash_scripts/functions.sh
@@ -160,6 +160,7 @@ add_site(){
     case $mode in
       link )
         read_by_def "   Enter path to links site (default: $path_site_from_links): " path_site_from_links $path_site_from_links;
+        export db_name=$(php -r '$settings = include "'$path_site_from_links'/bitrix/.settings.php"; echo $settings["connections"]["value"]["default"]["database"];')
       ;;
       full )
         read_by_def "   Enter database name: (default: $db_name): " db_name $db_name;


### PR DESCRIPTION
У сайта по умолчанию вместо шаблона используется статичный файл. Отредактировал его.   
У линков db_name перезаписывалась из баш-скрипта, что приводило к игнорированию переменной установленной через задачи в ansible.  

