### PR TITLE
Проверка существования имени бд и пользователя при создании full сайта

### DIFF
--- a/vm_menu/ansible/playbooks/roles/create_site/tasks/main.yml
+++ b/vm_menu/ansible/playbooks/roles/create_site/tasks/main.yml
@@ -97,7 +97,6 @@
       mysql_db:
         name: "{{ db_name }}"
         state: present
-      ignore_errors: yes
 
     - name: Creating database user
       mysql_user:
@@ -105,7 +104,6 @@
         password: "{{ db_password }}"
         priv: "{{ db_name }}.*:ALL"
         state: present
-      ignore_errors: yes
 
     - name: Creating directory bitrix/php_interface
       file:

--- a/vm_menu/bash_scripts/config.sh
+++ b/vm_menu/bash_scripts/config.sh
@@ -63,8 +63,8 @@ BS_ANSIBLE_PB_INSTALL_OR_DELETE_SPHINX="install_or_delete_sphinx.yaml"
 BS_ANSIBLE_PB_DELETE_SITE="delete_site.yaml"
 
 # Data Base
-BS_MAX_CHAR_DB_NAME=10
-BS_MAX_CHAR_DB_USER=10
+BS_MAX_CHAR_DB_NAME=20
+BS_MAX_CHAR_DB_USER=20
 BS_CHAR_DB_PASSWORD=24
 
 # NGINX configs
@@ -101,3 +101,5 @@ BS_URL_SCRIPT_UPDATE_MENU="https://raw.githubusercontent.com/EduardRe/DebianLike
 BS_REPOSITORY_URL="https://github.com/EduardRe/DebianLikeBitrixVM/"
 BS_CHECK_UPDATE_MENU_MINUTES=10
 
+# Mysql binary name
+BS_MYSQL_CMD="mysql"


### PR DESCRIPTION
В процессе тестирования заметил, что если создаются сайты с похожими именами (task111111.domain.tld task111111111111.domain.tld ), то имя бд и пользователя генерятся одинаковые и происходит перезапись пароля, что приводит к неработоспособности более старого сайта.

Здесь предлагается следующее:  
* Имя бд и пользователя проверяются на уникальность.
* Если такие уже существуют, то генерится хеш, который тоже проверяется на уникальность.
* Эти хеши предлагаются как данные по умолчанию.
* Ввод пользовательских значений по прежнему возможен и тоже проверяется на уникальность.
* Функция перенесена в блок full, чтобы не выдавать ошибку для link с похожим доменом.

Выглядит так:

```
   Menu -> Add a site:

   Enter site domain (example: example.com): task2222222222222222222222222222222222222222222222224444444.dom.tld
   Enter site mode link or full: full
Warning: Database 'db_task2222222222222' or User 'usr_task222222222222' already exists. Generating unique names...
   Enter database name: (default: db_ffb9d7319242a5f8): 
   Enter database user: (default: usr_ffb9d7319242a5f8): 
   Enter database password: (default: ]gO|6FN9_=ip6M<VX%=pC|uH): 
   Enter Y or N for setting SSL Let`s Encrypt site (default: N):
```