### PR TITLE
Переменная PUSH_KEY оставалсь пустой при создании дополнительных full сайтов

### DIFF
--- a/install_full_environment.sh
+++ b/install_full_environment.sh
@@ -78,7 +78,7 @@ password="${root_pass}"
 CONFIG_MYSQL_ROOT_MY_CNF
 
 # Clone directory vm_menu with repositories
-git clone --depth 1 --filter=blob:none --sparse $REPO_URL "$DEST_DIR_MENU/DebianLikeBitrixVM"
+git clone --branch=$BRANCH --depth 1 --filter=blob:none --sparse $REPO_URL "$DEST_DIR_MENU/DebianLikeBitrixVM"
 cd "$DEST_DIR_MENU/DebianLikeBitrixVM"
 git sparse-checkout set $DIR_NAME_MENU
 

--- a/install_full_environment.sh
+++ b/install_full_environment.sh
@@ -179,7 +179,9 @@ ansible-playbook "$DEST_DIR_MENU/$DIR_NAME_MENU/ansible/playbooks/${BS_ANSIBLE_P
 
   bx_cron_agents_path_file_after_document_root=${BS_BX_CRON_AGENTS_PATH_FILE_AFTER_DOCUMENT_ROOT} \
   bx_cron_logs_path_dir=${BS_BX_CRON_LOGS_PATH_DIR} \
-  bx_cron_logs_path_file=${BS_BX_CRON_LOGS_PATH_FILE}"
+  bx_cron_logs_path_file=${BS_BX_CRON_LOGS_PATH_FILE} \ 
+  
+  push_server_config=${BS_PUSH_SERVER_CONFIG}"
 
 echo -e "\n\n";
 echo "Full environment installed";

--- a/install_full_environment.sh
+++ b/install_full_environment.sh
@@ -179,9 +179,7 @@ ansible-playbook "$DEST_DIR_MENU/$DIR_NAME_MENU/ansible/playbooks/${BS_ANSIBLE_P
 
   bx_cron_agents_path_file_after_document_root=${BS_BX_CRON_AGENTS_PATH_FILE_AFTER_DOCUMENT_ROOT} \
   bx_cron_logs_path_dir=${BS_BX_CRON_LOGS_PATH_DIR} \
-  bx_cron_logs_path_file=${BS_BX_CRON_LOGS_PATH_FILE} \
-
-  push_key=${PUSH_KEY}"
+  bx_cron_logs_path_file=${BS_BX_CRON_LOGS_PATH_FILE}
 
 echo -e "\n\n";
 echo "Full environment installed";

--- a/install_full_environment.sh
+++ b/install_full_environment.sh
@@ -179,7 +179,7 @@ ansible-playbook "$DEST_DIR_MENU/$DIR_NAME_MENU/ansible/playbooks/${BS_ANSIBLE_P
 
   bx_cron_agents_path_file_after_document_root=${BS_BX_CRON_AGENTS_PATH_FILE_AFTER_DOCUMENT_ROOT} \
   bx_cron_logs_path_dir=${BS_BX_CRON_LOGS_PATH_DIR} \
-  bx_cron_logs_path_file=${BS_BX_CRON_LOGS_PATH_FILE}
+  bx_cron_logs_path_file=${BS_BX_CRON_LOGS_PATH_FILE}"
 
 echo -e "\n\n";
 echo "Full environment installed";

--- a/vm_menu/ansible/playbooks/install_new_full_environment.yaml
+++ b/vm_menu/ansible/playbooks/install_new_full_environment.yaml
@@ -91,6 +91,19 @@
         group: "{{ group_user_server_sites }}"
         mode: "{{ permissions_sites_files }}"
 
+    - name: Generate crypto key
+      ansible.builtin.set_fact:
+        crypto_key: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=32') }}"
+
+    - name: Read push-server config file
+      ansible.builtin.slurp:
+        src: "{{ push_server_config }}"
+      register: push_config_content
+
+    - name: Extract SECURITY_KEY and set push_key variable
+      ansible.builtin.set_fact:
+        push_key: "{{ push_config_content['content'] | b64decode | regex_search('SECURITY_KEY=\"([^\"]+)\"', '\\1') | first }}"
+
     - name: Generating .settings.php file
       template:
         dest: "{{ document_root }}/bitrix/.settings.php"

--- a/vm_menu/ansible/playbooks/roles/create_site/tasks/main.yml
+++ b/vm_menu/ansible/playbooks/roles/create_site/tasks/main.yml
@@ -121,6 +121,19 @@
         group: "{{ group_user_server_sites }}"
         mode: "{{ permissions_sites_files }}"
 
+    - name: Generate crypto key
+      ansible.builtin.set_fact:
+        crypto_key: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=32') }}"
+
+    - name: Read push-server config file
+      ansible.builtin.slurp:
+        src: "{{ push_server_config }}"
+      register: push_config_content
+
+    - name: Extract SECURITY_KEY and set push_key variable
+      ansible.builtin.set_fact:
+        push_key: "{{ push_config_content['content'] | b64decode | regex_search('SECURITY_KEY=\"([^\"]+)\"', '\\1') | first }}"
+
     - name: Generating .settings.php file
       template:
         dest: "{{ path_sites }}/{{ domain }}/bitrix/.settings.php"

--- a/vm_menu/ansible/playbooks/roles/create_site/templates/site_full_tpl/.settings.j2
+++ b/vm_menu/ansible/playbooks/roles/create_site/templates/site_full_tpl/.settings.j2
@@ -47,7 +47,7 @@ return array(
         array(
             'value' =>
                 array(
-                    'crypto_key' => '{{ push_key }}',
+                    'crypto_key' => '{{ crypto_key }}',
                 ),
             'readonly' => true,
         ),

--- a/vm_menu/bash_scripts/actions.sh
+++ b/vm_menu/bash_scripts/actions.sh
@@ -52,7 +52,7 @@ action_create_site(){
   bx_cron_logs_path_dir=${BS_BX_CRON_LOGS_PATH_DIR} \
   bx_cron_logs_path_file=${BS_BX_CRON_LOGS_PATH_FILE} \
 
-  push_key=\${PUSH_KEY} \
+  push_server_config=${BS_PUSH_SERVER_CONFIG} \
 
   pb_redirect_http_to_https=${pb_redirect_http_to_https} \
   ansible_run_playbooks_params=${BS_ANSIBLE_RUN_PLAYBOOKS_PARAMS}"

--- a/vm_menu/bash_scripts/config.sh
+++ b/vm_menu/bash_scripts/config.sh
@@ -103,3 +103,6 @@ BS_CHECK_UPDATE_MENU_MINUTES=10
 
 # Mysql binary name
 BS_MYSQL_CMD="mysql"
+
+# Push-server configs
+BS_PUSH_SERVER_CONFIG=/etc/sysconfig/push-server-multi


### PR DESCRIPTION
В шаблоне settings.php переменная PUSH_KEY бралась при начальной установке из стороннего скрипта. В дальнейшем она не назначалась, так что у доп сайтов full  в setting.php было просто записано {{ PUSH_KEY }}.

Сделал отдельную переменную для крипто ключа. Генерация согласно документации  https://dev.1c-bitrix.ru/learning/course/index.php?COURSE_ID=43&LESSON_ID=14036

PUSH_KEY  теперь берётся из конфига push-server и переменная доступна всегда, в том числе и для доп сайтов.

Протеcтировал чистое развёртывание. И сайт по умолчанию и доп сайт full теперь имеют уникальный secure_key и корректный push_key. 

Также мелкое дополнение. Добавлено указание ветки для клонирования репозитория, это повышает удобство тестирования доработок, которые находятся в других ветках.