### PR TITLE
Added use of symlinks for the list of sites

### DIFF
--- a/vm_menu/bash_scripts/utils.sh
+++ b/vm_menu/bash_scripts/utils.sh
@@ -24,7 +24,7 @@ list_sites(){
   # Функция для заполнения массива данными
   fill_array() {
     local index=0
-    for tmp_dir in $(find "$BS_PATH_SITES" -maxdepth 1 -type d | grep -v "^$BS_PATH_SITES$" | sed 's|.*/||'); do
+    for tmp_dir in $(find "$BS_PATH_SITES" -maxdepth 1 -type d -o -type l | grep -v "^$BS_PATH_SITES$" | sed 's|.*/||'); do
 
       if [[ $tmp_dir =~ ^\. ]]; then
         continue


### PR DESCRIPTION
Корректировка фильтра для учета символьных ссылок делает решение более универсальным, так как не обязывает пользователей сохранять предлагаемую файловую структуру при развертывании, но при этом - сохраняет все конфиги в исходном виде.
В частности, упрощается миграция с окружения BitrixVM, если корнем репозитория на проекте выбран каталог /home/bitrix/. Это часто встречается при использовании многосайтовости на BitrixVM.